### PR TITLE
Mejoras menores

### DIFF
--- a/ortograf/afijos/afijos.txt
+++ b/ortograf/afijos/afijos.txt
@@ -95,7 +95,7 @@ PFX f Y 6
 PFX f 0         con       [^abehilopru]
 PFX f 0         con       ll
 PFX f 0         com       pb
-PFX f 0         co        [aehiou]
+PFX f 0         co        [aehioupd]
 PFX f 0         co        l[^l]
 PFX f 0         cor       r
 
@@ -142,6 +142,11 @@ PFX l 0         inter     .
 PFX m Y 2
 PFX m 0         micro     [^r]
 PFX m 0         micror    r
+
+# Prefijo pos-/post-: Significa 'detrás de', 'después de'.
+PFX o Y 2
+PFX o 0         pos       [^s]
+PFX o 0         post      [^t]
 
 # Prefijo pre-: Significa 'anterioridad local o temporal', 'prioridad' o
 # 'encarecimiento'.

--- a/ortograf/afijos/afijos.txt
+++ b/ortograf/afijos/afijos.txt
@@ -259,6 +259,13 @@ SFX F te        cia/S        ante
 SFX F te        cia/S        [^i]ente
 SFX F iente     encia/S      iente
 
+# Sufijo -nte (-ante, -ente, -iente): Participio activo, que denota capacidad
+# de realizar la acción que expresa el verbo del que deriva.
+SFX ü Y 3
+SFX ü r         nte/S        ar
+SFX ü er        iente/S      er
+SFX ü ir        ente/S       ir
+
 # Sufijo -azo: Tiene sentido aumentativo, expresa sentido despectivo y a veces
 # significa 'golpe'. Relaciona sustantivos y adjetivos con sustantivos
 # masculinos.

--- a/ortograf/afijos/afijos.txt
+++ b/ortograf/afijos/afijos.txt
@@ -144,9 +144,9 @@ PFX m 0         micro     [^r]
 PFX m 0         micror    r
 
 # Prefijo pos-/post-: Significa 'detrás de', 'después de'.
-PFX o Y 2
-PFX o 0         pos       [^s]
-PFX o 0         post      [^t]
+PFX ö Y 2
+PFX ö 0         pos       [^s]
+PFX ö 0         post      [^t]
 
 # Prefijo pre-: Significa 'anterioridad local o temporal', 'prioridad' o
 # 'encarecimiento'.

--- a/ortograf/palabras/RAE/NombresComunes.txt
+++ b/ortograf/palabras/RAE/NombresComunes.txt
@@ -61,6 +61,10 @@ anecdotista/S
 anestesista/S
 anormal/S
 antagonista/S
+antefuturo/S
+antepospretérito/S
+antepresente/S
+antepretérito/S
 anticresista/S
 aparcacoches
 apátrida/S
@@ -244,6 +248,7 @@ copartícipe/S
 copiloto/S
 copista/S
 coplista/S
+copretérito/S
 corista/S
 coriza/S
 cornista/S
@@ -602,6 +607,7 @@ portamira/S
 portanuevas
 portavoz/S
 posma/S
+pospretérito/S
 postulante/S
 potista/S
 practicante/S

--- a/ortograf/palabras/RAE/VerbosTransitivos.txt
+++ b/ortograf/palabras/RAE/VerbosTransitivos.txt
@@ -3755,7 +3755,7 @@ volatizar/REDT
 volear/RED
 voltejear/RED
 vomitar/REDÀÁÂÄ
-vosear/RED
+vosear/REDü
 vulcanizar/REDA
 vulnerar/REDAÀ
 xerocopiar/RED

--- a/ortograf/palabras/RAE/VerbosTransitivosIntransitivos.txt
+++ b/ortograf/palabras/RAE/VerbosTransitivosIntransitivos.txt
@@ -342,6 +342,7 @@ jalar/REDÁÄ
 jarbar/RED
 jinetear/RED
 jornalar/RED
+jugar/REDÀÄT
 jurar/REDÀÁÂÃÅÆÌÍÏÙÚ
 laborar/RED
 laborear/RED
@@ -435,6 +436,7 @@ pitar/REDÂ
 planear/REDÀ
 plantear/REDÀÁÆ
 platicar/REDÀÂÍ
+poder/REDÀÁÂ
 poetizar/RED
 potrear/RED
 practicar/REDÀÄ

--- a/ortograf/palabras/RAE/VerbosTransitivosIntransitivosPronominales.txt
+++ b/ortograf/palabras/RAE/VerbosTransitivosIntransitivosPronominales.txt
@@ -444,7 +444,7 @@ mover/IRDÄÁÝñòõù
 mudar/REDÁñò
 multiplicar/REDÀÄñòôøT
 ociar/RED
-oler/RD
+oler/RED
 operar/REDÀÁÂñô
 orillar/REDñò
 orinar/REDñ


### PR DESCRIPTION
El prefijo co- puede aplicarse también a palabras que comienzan con P o D, como copiloto, coparticipar o codirector.

El sufijo -nte (-ante/-ente) para formar el participio activo, sólo en aquellos que no se han convertido en sustantivos o adjetivos. Por ejemplo la palabra "voseante" (ámpliamente usada por la RAE en su web) no existe como adjetivo, por lo que entiendo que debe ser formada como participio activo del verbo vosear.

Se declararon los verbos jugar y poder, que no estaban definidos como verbos, sólo sus conjugaciones estaban declaradas en el archivo de irregulares.

Algunos nombres de tiempos verbales como antefuturo y copretérito, admitidos por la RAE y usados en los propios textos de su web.