### PR TITLE
Issue #6 - Añado el verbo transitivo "victimizar" y el adjetivo "ganoso"

### DIFF
--- a/ortograf/palabras/RAE/Adjetivos.txt
+++ b/ortograf/palabras/RAE/Adjetivos.txt
@@ -5675,6 +5675,7 @@ gandul/GS
 ganglionar/S
 gangoso/GS
 gangrenoso/SG
+ganoso/GS
 ganso/GS
 garante/S
 garantizador/SG

--- a/ortograf/palabras/RAE/VerbosTransitivos.txt
+++ b/ortograf/palabras/RAE/VerbosTransitivos.txt
@@ -3737,6 +3737,7 @@ vertebrar/RED
 vetar/REDÀ
 vetear/RED
 victimar/RED
+victimizar/REDÌÎÙÚôø
 victorear/RED
 vigiar/IRD
 vilipendiar/RED


### PR DESCRIPTION
Al añadir el adjetivo ganoso con su respectivos afijos de género y plurales, se encuentran disponible las siguientes palabras:
* ganoso
* ganosos
* ganosa
* ganosas

Se añadió el verbo victimizar con sus respectivos afijos de conjugaciones (no transcribo todas las palabras porque son más de 50).