### PR TITLE
Mejoras al código del script make_dict.sh

### DIFF
--- a/ortograf/herramientas/make_dict.sh
+++ b/ortograf/herramientas/make_dict.sh
@@ -154,7 +154,6 @@ echo "¡listo!"
 # comunes a todos los idiomas, más los de la localización solicitada.
 # Si se crea el diccionario genérico, se incluyen todas las localizaciones.
 TMPWLIST="$MDTMPDIR/wordlist.tmp"
-WLIST="$MDTMPDIR/wordlist.txt"
 echo -n "Creando la lista de lemas etiquetados... "
 
 # Palabras comunes a todos los idiomas, definidas por la RAE.
@@ -435,7 +434,7 @@ else
 fi
 
 cd "$MDTMPDIR"
-$ZIP -r -q "$ZIPFILE" *
+$ZIP -r -q "$ZIPFILE" ./*
 cd "$DIRECTORIO_TRABAJO"
 echo "¡listo!"
 

--- a/ortograf/herramientas/make_dict.sh
+++ b/ortograf/herramientas/make_dict.sh
@@ -6,10 +6,10 @@
 # Este programa se distribuye bajo licencia GNU GPL.
 
 # Herramientas básicas para el script
-MKTEMP=`which mktemp 2>/dev/null`
-GREP=`which grep 2>/dev/null`
-FIND=`which find 2>/dev/null`
-ZIP=`which zip 2>/dev/null`
+MKTEMP=$(which mktemp 2>/dev/null)
+GREP=$(which grep 2>/dev/null)
+FIND=$(which find 2>/dev/null)
+ZIP=$(which zip 2>/dev/null)
 
 # Abandonar si no se encuentra alguna de las herramientas
 if [ "$MKTEMP" == "" ]; then
@@ -44,7 +44,7 @@ do
     continue
   fi
 
-  argumento=`expr "z$opcion" : 'z[^=]*=\(.*\)'`
+  argumento=$(expr "z$opcion" : 'z[^=]*=\(.*\)')
 
   case $opcion in
 
@@ -131,7 +131,7 @@ else
 fi
 
 # Crear un directorio temporal de trabajo
-MDTMPDIR="`$MKTEMP -d /tmp/makedict.XXXXXXXXXX`"
+MDTMPDIR="$($MKTEMP -d /tmp/makedict.XXXXXXXXXX)"
 
 # Para el fichero de afijos encadenamos los distintos segmentos (encabezado,
 # prefijos y sufijos) de la localización seleccionada, eliminando los
@@ -167,7 +167,7 @@ if [ -d "../palabras/RAE/l10n/$LOCALIZACION" ]; then
     >> $TMPWLIST
 else
   # Diccionario genérico; incluir todas las localizaciones.
-  cat `$FIND ../palabras/RAE/l10n/ -iname "*.txt" -and ! -regex '.*/\.svn.*'` \
+  cat $($FIND ../palabras/RAE/l10n/ -iname "*.txt" -and ! -regex '.*/\.svn.*') \
     | ./remover_comentarios.sh \
     >> $TMPWLIST
 fi
@@ -196,15 +196,15 @@ if [ "$RAE" != "SÍ" ]; then
       >> $TMPWLIST
   else
     # Diccionario genérico; incluir todas las localizaciones.
-    cat `$FIND ../palabras/noRAE/l10n/ \
-               -iname "*.txt" -and ! -regex '.*/\.svn.*'` \
+    cat $($FIND ../palabras/noRAE/l10n/ \
+               -iname "*.txt" -and ! -regex '.*/\.svn.*') \
       | ./remover_comentarios.sh \
       >> $TMPWLIST
 
     # Issue #39 - Incluir topónimos de todas las localizaciones (pendiente de
     # definir condiciones de inclusión)
-    cat `$FIND ../palabras/toponimos/l10n/ \
-               -iname "toponimos-*.txt" -and ! -regex '.*/\.svn.*'` \
+    cat $($FIND ../palabras/toponimos/l10n/ \
+               -iname "toponimos-*.txt" -and ! -regex '.*/\.svn.*') \
       | ./remover_comentarios.sh \
       >> $TMPWLIST
   fi
@@ -430,7 +430,7 @@ if [ "$VERSION" != "2" ]; then
   cp ../docs/manifest.xml $MDTMPDIR/META-INF
 fi
 
-DIRECTORIO_TRABAJO="`pwd`"
+DIRECTORIO_TRABAJO="$(pwd)"
 
 if [ "$VERSION" != "3" ]; then
   echo -n "Creando paquete comprimido para las versiones 1.x o 2.x de OpenOffice.org... "

--- a/ortograf/herramientas/make_dict.sh
+++ b/ortograf/herramientas/make_dict.sh
@@ -353,70 +353,20 @@ case $LOCALIZACION in
     ;;
 esac
 
-cat ../docs/README_base.txt \
-  | sed -n --expression="
-    /__/! { p; };
-    /__LOCALE__/ { s//$LOCALIZACION/g; p; };
-    /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
-    /__LOCALE_TEXT__/ {s//$TEXTO_LOCAL/g; p; };
-    /__COUNTRY__/ { s//$PAIS/g; p; }" \
-  > "$MDTMPDIR/README.txt"
+sed -n --expression="
+  /__/! { p; };
+  /__LOCALE__/ { s//$LOCALIZACION/g; p; };
+  /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
+  /__LOCALE_TEXT__/ {s//$TEXTO_LOCAL/g; p; };
+  /__COUNTRY__/ { s//$PAIS/g; p; }" \
+  ../docs/README_base.txt > "$MDTMPDIR/README.txt"
 cp ../docs/Changelog.txt ../docs/GPLv3.txt ../docs/LGPLv3.txt \
   ../docs/MPL-1.1.txt "$MDTMPDIR"
 
 if [ "$VERSION" != "2" ]; then
   if [ "$COMPLETO" != "SÍ" ]; then
     DESCRIPCION="Español ($PAIS): Ortografía"
-    cat ../docs/dictionaries.xcu \
-      | sed -n --expression="
-        /__/! { p; };
-        /__LOCALE__/ { s//$LOCALIZACION/g; p; };
-        /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
-        /__LOCALE_TEXT__/ { s//$TEXTO_LOCAL/g; p; };
-        /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
-        /__ICON__/ { s//$ICONO/g; p; };
-        /__COUNTRY__/ { s//$PAIS/g; p; }" \
-      > "$MDTMPDIR/dictionaries.xcu"
-    cat ../docs/package-description.txt \
-      | sed -n --expression="
-        /__/! { p; };
-        /__LOCALE__/ { s//$LOCALIZACION/g; p; };
-        /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
-        /__LOCALE_TEXT__/ { s//$TEXTO_LOCAL/g; p; };
-        /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
-        /__ICON__/ { s//$ICONO/g; p; };
-        /__COUNTRY__/ { s//$PAIS/g; p; }" \
-      > "$MDTMPDIR/package-description.txt"
-  else
-    DESCRIPCION="Español ($PAIS): Ortografía, separación y sinónimos"
-    cat ../docs/dictionaries_full.xcu \
-      | sed -n --expression="
-        /__/! { p; };
-        /__LOCALE__/ { s//$LOCALIZACION/g; p; };
-        /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
-        /__LOCALE_TEXT__/ { s//$TEXTO_LOCAL/g; p; };
-        /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
-        /__ICON__/ { s//$ICONO/g; p; };
-        /__COUNTRY__/ { s//$PAIS/g; p; }" \
-      > "$MDTMPDIR/dictionaries.xcu"
-    cat ../docs/package-description_full.txt \
-      | sed -n --expression="
-        /__/! { p; };
-        /__LOCALE__/ { s//$LOCALIZACION/g; p; };
-        /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
-        /__LOCALE_TEXT__/ { s//$TEXTO_LOCAL/g; p; };
-        /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
-        /__ICON__/ { s//$ICONO/g; p; };
-        /__COUNTRY__/ { s//$PAIS/g; p; }" \
-      > "$MDTMPDIR/package-description.txt"
-    cp ../../separacion/hyph_es_ANY.dic \
-      ../../separacion/README_hyph_es_ANY.txt "$MDTMPDIR"
-    cp ../../sinonimos/palabras/README_th_es_ES.txt \
-      ../../sinonimos/palabras/COPYING_th_es_ES \
-      ../../sinonimos/palabras/th_es_ES_v2.* "$MDTMPDIR"
-  fi
-  cat ../docs/description.xml \
-    | sed -n --expression="
+    sed -n --expression="
       /__/! { p; };
       /__LOCALE__/ { s//$LOCALIZACION/g; p; };
       /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
@@ -424,7 +374,51 @@ if [ "$VERSION" != "2" ]; then
       /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
       /__ICON__/ { s//$ICONO/g; p; };
       /__COUNTRY__/ { s//$PAIS/g; p; }" \
-    > "$MDTMPDIR/description.xml"
+    ../docs/dictionaries.xcu> "$MDTMPDIR/dictionaries.xcu"
+    sed -n --expression="
+      /__/! { p; };
+      /__LOCALE__/ { s//$LOCALIZACION/g; p; };
+      /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
+      /__LOCALE_TEXT__/ { s//$TEXTO_LOCAL/g; p; };
+      /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
+      /__ICON__/ { s//$ICONO/g; p; };
+      /__COUNTRY__/ { s//$PAIS/g; p; }" \
+    ../docs/package-description.txt > "$MDTMPDIR/package-description.txt"
+  else
+    DESCRIPCION="Español ($PAIS): Ortografía, separación y sinónimos"
+    sed -n --expression="
+      /__/! { p; };
+      /__LOCALE__/ { s//$LOCALIZACION/g; p; };
+      /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
+      /__LOCALE_TEXT__/ { s//$TEXTO_LOCAL/g; p; };
+      /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
+      /__ICON__/ { s//$ICONO/g; p; };
+      /__COUNTRY__/ { s//$PAIS/g; p; }" \
+    ../docs/dictionaries_full.xcu > "$MDTMPDIR/dictionaries.xcu"
+    sed -n --expression="
+      /__/! { p; };
+      /__LOCALE__/ { s//$LOCALIZACION/g; p; };
+      /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
+      /__LOCALE_TEXT__/ { s//$TEXTO_LOCAL/g; p; };
+      /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
+      /__ICON__/ { s//$ICONO/g; p; };
+      /__COUNTRY__/ { s//$PAIS/g; p; }" \
+    ../docs/package-description_full.txt > "$MDTMPDIR/package-description.txt"
+    cp ../../separacion/hyph_es_ANY.dic \
+      ../../separacion/README_hyph_es_ANY.txt "$MDTMPDIR"
+    cp ../../sinonimos/palabras/README_th_es_ES.txt \
+      ../../sinonimos/palabras/COPYING_th_es_ES \
+      ../../sinonimos/palabras/th_es_ES_v2.* "$MDTMPDIR"
+  fi
+  sed -n --expression="
+    /__/! { p; };
+    /__LOCALE__/ { s//$LOCALIZACION/g; p; };
+    /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
+    /__LOCALE_TEXT__/ { s//$TEXTO_LOCAL/g; p; };
+    /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
+    /__ICON__/ { s//$ICONO/g; p; };
+    /__COUNTRY__/ { s//$PAIS/g; p; }" \
+  ../docs/description.xml > "$MDTMPDIR/description.xml"
   cp ../docs/$ICONO "$MDTMPDIR"
   mkdir "$MDTMPDIR/META-INF"
   cp ../docs/manifest.xml "$MDTMPDIR/META-INF"

--- a/ortograf/herramientas/make_dict.sh
+++ b/ortograf/herramientas/make_dict.sh
@@ -143,10 +143,10 @@ if [ ! -f ../afijos/l10n/$LOCALIZACION/afijos.txt ]; then
   # Si se solicitó un diccionario genérico, o la localización no ha
   # definido sus propias reglas para los afijos, utilizamos la versión
   # genérica de los ficheros.
-  ./remover_comentarios.sh < ../afijos/afijos.txt > $AFFIX
+  ./remover_comentarios.sh < ../afijos/afijos.txt > "$AFFIX"
 else
   # Se usa la versión de la localización solicitada.
-  ./remover_comentarios.sh < ../afijos/l10n/$LOCALIZACION/afijos.txt > $AFFIX
+  ./remover_comentarios.sh < ../afijos/l10n/$LOCALIZACION/afijos.txt > "$AFFIX"
 fi
 echo "¡listo!"
 
@@ -158,64 +158,64 @@ WLIST="$MDTMPDIR/wordlist.txt"
 echo -n "Creando la lista de lemas etiquetados... "
 
 # Palabras comunes a todos los idiomas, definidas por la RAE.
-cat ../palabras/RAE/*.txt | ./remover_comentarios.sh > $TMPWLIST
+cat ../palabras/RAE/*.txt | ./remover_comentarios.sh > "$TMPWLIST"
 
 if [ -d "../palabras/RAE/l10n/$LOCALIZACION" ]; then
   # Incluir las palabras de la localización solicitada, definidas por la RAE.
   cat ../palabras/RAE/l10n/$LOCALIZACION/*.txt \
     | ./remover_comentarios.sh \
-    >> $TMPWLIST
+    >> "$TMPWLIST"
 else
   # Diccionario genérico; incluir todas las localizaciones.
   cat $($FIND ../palabras/RAE/l10n/ -iname "*.txt" -and ! -regex '.*/\.svn.*') \
     | ./remover_comentarios.sh \
-    >> $TMPWLIST
+    >> "$TMPWLIST"
 fi
 
 if [ "$RAE" != "SÍ" ]; then
   # Incluir palabras comunes, no definidas por la RAE
-  cat ../palabras/noRAE/*.txt | ./remover_comentarios.sh >> $TMPWLIST
+  cat ../palabras/noRAE/*.txt | ./remover_comentarios.sh >> "$TMPWLIST"
 
   # Issue #39 - Incluir topónimos
   # Se especifica un prefijo de nombre de archivo porque hay directorios que
   # contienen archivos con explicaciones (p.e.: es_ES)
   cat ../palabras/toponimos/toponimos-*.txt \
     | ./remover_comentarios.sh \
-    >> $TMPWLIST
+    >> "$TMPWLIST"
 
   if [ -d "../palabras/noRAE/l10n/$LOCALIZACION" ]; then
     # Incluir las palabras de la localización solicitada.
     cat ../palabras/noRAE/l10n/$LOCALIZACION/*.txt \
       | ./remover_comentarios.sh \
-      >> $TMPWLIST
+      >> "$TMPWLIST"
 
     # Issue #39 - Incluir topónimos de la localización (pendiente de definir
     # condiciones de inclusión)
     cat ../palabras/toponimos/l10n/$LOCALIZACION/toponimos-*.txt \
       | ./remover_comentarios.sh \
-      >> $TMPWLIST
+      >> "$TMPWLIST"
   else
     # Diccionario genérico; incluir todas las localizaciones.
     cat $($FIND ../palabras/noRAE/l10n/ \
                -iname "*.txt" -and ! -regex '.*/\.svn.*') \
       | ./remover_comentarios.sh \
-      >> $TMPWLIST
+      >> "$TMPWLIST"
 
     # Issue #39 - Incluir topónimos de todas las localizaciones (pendiente de
     # definir condiciones de inclusión)
     cat $($FIND ../palabras/toponimos/l10n/ \
                -iname "toponimos-*.txt" -and ! -regex '.*/\.svn.*') \
       | ./remover_comentarios.sh \
-      >> $TMPWLIST
+      >> "$TMPWLIST"
   fi
 fi
 
 # Generar el fichero con la lista de palabras (únicas), indicando en la
 # primera línea el número de palabras que contiene.
 DICFILE="$MDTMPDIR/$LOCALIZACION.dic"
-sort -u < $TMPWLIST | wc -l | cut -d ' ' -f1 > $DICFILE
-sort -u < $TMPWLIST >> $DICFILE
-rm -f $TMPWLIST
+sort -u < "$TMPWLIST" | wc -l | cut -d ' ' -f1 > "$DICFILE"
+sort -u < "$TMPWLIST" >> "$DICFILE"
+rm -f "$TMPWLIST"
 echo "¡listo!"
 
 # Restauramos la variable de entorno LANG
@@ -360,9 +360,9 @@ cat ../docs/README_base.txt \
     /__LOCALES__/ {s//$LOCALIZACIONES/g; p; };
     /__LOCALE_TEXT__/ {s//$TEXTO_LOCAL/g; p; };
     /__COUNTRY__/ { s//$PAIS/g; p; }" \
-  > $MDTMPDIR/README.txt
+  > "$MDTMPDIR/README.txt"
 cp ../docs/Changelog.txt ../docs/GPLv3.txt ../docs/LGPLv3.txt \
-  ../docs/MPL-1.1.txt $MDTMPDIR
+  ../docs/MPL-1.1.txt "$MDTMPDIR"
 
 if [ "$VERSION" != "2" ]; then
   if [ "$COMPLETO" != "SÍ" ]; then
@@ -376,7 +376,7 @@ if [ "$VERSION" != "2" ]; then
         /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
         /__ICON__/ { s//$ICONO/g; p; };
         /__COUNTRY__/ { s//$PAIS/g; p; }" \
-      > $MDTMPDIR/dictionaries.xcu
+      > "$MDTMPDIR/dictionaries.xcu"
     cat ../docs/package-description.txt \
       | sed -n --expression="
         /__/! { p; };
@@ -386,7 +386,7 @@ if [ "$VERSION" != "2" ]; then
         /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
         /__ICON__/ { s//$ICONO/g; p; };
         /__COUNTRY__/ { s//$PAIS/g; p; }" \
-      > $MDTMPDIR/package-description.txt
+      > "$MDTMPDIR/package-description.txt"
   else
     DESCRIPCION="Español ($PAIS): Ortografía, separación y sinónimos"
     cat ../docs/dictionaries_full.xcu \
@@ -398,7 +398,7 @@ if [ "$VERSION" != "2" ]; then
         /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
         /__ICON__/ { s//$ICONO/g; p; };
         /__COUNTRY__/ { s//$PAIS/g; p; }" \
-      > $MDTMPDIR/dictionaries.xcu
+      > "$MDTMPDIR/dictionaries.xcu"
     cat ../docs/package-description_full.txt \
       | sed -n --expression="
         /__/! { p; };
@@ -408,12 +408,12 @@ if [ "$VERSION" != "2" ]; then
         /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
         /__ICON__/ { s//$ICONO/g; p; };
         /__COUNTRY__/ { s//$PAIS/g; p; }" \
-      > $MDTMPDIR/package-description.txt
+      > "$MDTMPDIR/package-description.txt"
     cp ../../separacion/hyph_es_ANY.dic \
-      ../../separacion/README_hyph_es_ANY.txt $MDTMPDIR
+      ../../separacion/README_hyph_es_ANY.txt "$MDTMPDIR"
     cp ../../sinonimos/palabras/README_th_es_ES.txt \
       ../../sinonimos/palabras/COPYING_th_es_ES \
-      ../../sinonimos/palabras/th_es_ES_v2.* $MDTMPDIR
+      ../../sinonimos/palabras/th_es_ES_v2.* "$MDTMPDIR"
   fi
   cat ../docs/description.xml \
     | sed -n --expression="
@@ -424,10 +424,10 @@ if [ "$VERSION" != "2" ]; then
       /__DESCRIPTION__/ { s//$DESCRIPCION/g; p; };
       /__ICON__/ { s//$ICONO/g; p; };
       /__COUNTRY__/ { s//$PAIS/g; p; }" \
-    > $MDTMPDIR/description.xml
-  cp ../docs/$ICONO $MDTMPDIR
+    > "$MDTMPDIR/description.xml"
+  cp ../docs/$ICONO "$MDTMPDIR"
   mkdir "$MDTMPDIR/META-INF"
-  cp ../docs/manifest.xml $MDTMPDIR/META-INF
+  cp ../docs/manifest.xml "$MDTMPDIR/META-INF"
 fi
 
 DIRECTORIO_TRABAJO="$(pwd)"
@@ -440,12 +440,12 @@ else
   ZIPFILE="$DIRECTORIO_TRABAJO/$LOCALIZACION.oxt"
 fi
 
-cd $MDTMPDIR
-$ZIP -r -q $ZIPFILE *
-cd $DIRECTORIO_TRABAJO
+cd "$MDTMPDIR"
+$ZIP -r -q "$ZIPFILE" *
+cd "$DIRECTORIO_TRABAJO"
 echo "¡listo!"
 
 # Eliminar la carpeta temporal
-rm -Rf $MDTMPDIR
+rm -Rf "$MDTMPDIR"
 
 echo "¡Proceso finalizado!"


### PR DESCRIPTION
Con la ayuda de la [guía de estilos de Google](https://google.github.io/styleguide/shell.xml) y el validador [shellcheck](https://github.com/koalaman/shellcheck), he implementado algunas mejoras al _script_ que me gustaría compartir.

* [SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006): Se reemplazó `` `..` `` por `$(..)` que se considera más estable y seguro.
* [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086): Se agrega doble comillas a las variables para evitar que se separen las palabras y se expandan las _wildcards_.
* [SC2002](https://github.com/koalaman/shellcheck/wiki/SC2002): Elimino el uso innecesario del comando `cat`. Su uso se considera innecesario cuando no se usa con la finalidad de concatenar archivos, que es la funcionalidad para que fue creado el comando.
* [SC2034](https://github.com/koalaman/shellcheck/wiki/SC2034): Elimino variables que no se usan, en este caso "WLIST".
* [SC2035](https://github.com/koalaman/shellcheck/wiki/SC2035): Corrijo el uso del _wildcard_ `*` cuando se hace referencia a todos los archivos de un directorio.

Si corren el _shellcheck_, se van a encontrar que siguen apareciendo algunas recomendaciones más. Aún no las revisé y como seguramente pase mucho tiempo hasta que vuelva a ver el _script_, comparto las mejoras para incluirlas al repositorio original.

Luego de las mejoras corrí varias veces el _script_ con diversas combinaciones de opciones y no falla en ninguna. Además, he comparado mediante hash md5 los archivos que contiene el zip generado con el _script_ mejorado contra los archivos del zip generado con el código viejo. Los archivos contienen los mismos _hashes_, por lo que la salida es la misma en ambas versiones del _script_.

¿Qué me motivó a hacer estas mejoras? Cuando iba añadiendo palabras de uno de los _issues_ en los que estaba trabajando, luego de generar el diccionario abro el zip para incrementar el numero de versión y cambio el ID del diccionario, para que no me reemplace el que ya tengo instalado en LibreOffice. Entonces pensé que una buena mejora sería que el número de versión sea una variable del _script_ y desde ahí se asigna a los diversos archivos. Como también sería interesante el agregado de un _flag_ `--beta` o `--pruebas` para que cambie el ID del diccionario y no me actualice el diccionario estable que ya tenga instalado en LibreOffice.

Finalmente no implementé esas mejoras porque me pareció más pertinente hacer más robusto y seguro el _script_ antes de agregar estas funcionalidades.