### PR TITLE
Agregar la palabra [mueblería] y su plural

### DIFF
--- a/ortograf/palabras/RAE/NombresFemeninos.txt
+++ b/ortograf/palabras/RAE/NombresFemeninos.txt
@@ -7115,6 +7115,7 @@ mucosa/S
 mucosidad/S
 mudanza/S
 muda/SM
+mueblería/S
 mueca/S
 muela/S
 muera/S


### PR DESCRIPTION
mueblería
1. f. Taller en que se hacen muebles.
2. f. Tienda de muebles.