### PR TITLE
Agregar la palabra [plafón]

### DIFF
--- a/ortograf/palabras/RAE/NombresMasculinos.txt
+++ b/ortograf/palabras/RAE/NombresMasculinos.txt
@@ -9854,6 +9854,7 @@ placebo/S
 placentario/S
 placer/hS
 placimiento/S
+plafón/S
 planchazo/S
 planco/S
 plancton


### PR DESCRIPTION
plafón

Del fr. plafond.
1. m. Adorno en la parte central del techo de una habitación, en el cual está el soporte para suspender la lámpara.
2. m. Lámpara plana traslúcida, que se coloca pegada al techo para disimular las bombillas.
3. m. Arq. Plano inferior del saliente de una cornisa.