### PR TITLE
Agregar la palabra [quirófano]

### DIFF
--- a/ortograf/palabras/RAE/NombresMasculinos.txt
+++ b/ortograf/palabras/RAE/NombresMasculinos.txt
@@ -10462,6 +10462,7 @@ quirate/S
 quirguiz/S
 quirie/S
 quirite/S
+quirófano/S
 quiróptero/S
 quiste/S
 quitador/S


### PR DESCRIPTION
quirófano
De quiro- y el gr. φαίνειν phaínein 'mostrar'.
1. m. Local convenientemente acondicionado para hacer operaciones quirúrgicas de manera que puedan presenciarse al través de una separación de cristal, y, por ext., cualquier sala donde se efectúan estas operaciones.