### PR TITLE
Agregar la palabra [abajeño]

### DIFF
--- a/ortograf/palabras/RAE/l10n/es_AR/Adjetivos.txt
+++ b/ortograf/palabras/RAE/l10n/es_AR/Adjetivos.txt
@@ -14,6 +14,7 @@
 # Debe haber recibido una copia de la Licencia Pública General de GNU junto
 # con este listado. Si no es así, visite <http://www.gnu.org/licenses/>
 
+abajeño/GS
 abatanado/GS
 acodillado/SG
 agalludo/GS

--- a/ortograf/palabras/RAE/l10n/es_BO/Adjetivos.txt
+++ b/ortograf/palabras/RAE/l10n/es_BO/Adjetivos.txt
@@ -14,6 +14,7 @@
 # Debe haber recibido una copia de la Licencia Pública General de GNU junto
 # con este listado. Si no es así, visite <http://www.gnu.org/licenses/>
 
+abajeño/GS
 abatanado/GS
 acusete/S
 alhaja/S

--- a/ortograf/palabras/RAE/l10n/es_DO/Adjetivos.txt
+++ b/ortograf/palabras/RAE/l10n/es_DO/Adjetivos.txt
@@ -14,6 +14,7 @@
 # Debe haber recibido una copia de la Licencia Pública General de GNU junto
 # con este listado. Si no es así, visite <http://www.gnu.org/licenses/>
 
+abajeño/GS
 abatanado/GS
 acomedido/GS
 alón/SG

--- a/ortograf/palabras/RAE/l10n/es_EC/Adjetivos.txt
+++ b/ortograf/palabras/RAE/l10n/es_EC/Adjetivos.txt
@@ -14,6 +14,7 @@
 # Debe haber recibido una copia de la Licencia Pública General de GNU junto
 # con este listado. Si no es así, visite <http://www.gnu.org/licenses/>
 
+abajeño/GS
 abatanado/GS
 aborlonado/GS
 acomedido/GS

--- a/ortograf/palabras/RAE/l10n/es_MX/Adjetivos.txt
+++ b/ortograf/palabras/RAE/l10n/es_MX/Adjetivos.txt
@@ -14,6 +14,7 @@
 # Debe haber recibido una copia de la Licencia Pública General de GNU junto
 # con este listado. Si no es así, visite <http://www.gnu.org/licenses/>
 
+abajeño/GS
 abatanado/GS
 acomedido/GS
 alón/SG

--- a/ortograf/palabras/RAE/l10n/es_NI/Adjetivos.txt
+++ b/ortograf/palabras/RAE/l10n/es_NI/Adjetivos.txt
@@ -14,6 +14,7 @@
 # Debe haber recibido una copia de la Licencia Pública General de GNU junto
 # con este listado. Si no es así, visite <http://www.gnu.org/licenses/>
 
+abajeño/GS
 abatanado/GS
 acomedido/GS
 acompañado/GS

--- a/ortograf/palabras/RAE/l10n/es_PE/Adjetivos.txt
+++ b/ortograf/palabras/RAE/l10n/es_PE/Adjetivos.txt
@@ -14,6 +14,7 @@
 # Debe haber recibido una copia de la Licencia Pública General de GNU junto
 # con este listado. Si no es así, visite <http://www.gnu.org/licenses/>
 
+abajeño/GS
 abatanado/GS
 acomedido/GS
 acusete/S


### PR DESCRIPTION
 abajeño, ña
De abajo.
1. adj. Natural del Bajío, región de los estados de Guanajuato, Michoacán y Jalisco, en México. U. t. c. s.
2. adj. Perteneciente o relativo al Bajío o a los abajeños.
3. adj. Arg., Bol., Ec., Méx., Nic., Perú y R. Dom. Natural o procedente de costas y tierras bajas. U. t. c. s.