### PR TITLE
[+] Agrego el nombre masculino [veganismo] a RAE

### DIFF
--- a/ortograf/palabras/RAE/NombresMasculinos.txt
+++ b/ortograf/palabras/RAE/NombresMasculinos.txt
@@ -13026,6 +13026,7 @@ vedado/S
 vedamiento/S
 vedegambre/S
 veedor/prS
+veganismo
 vegetalismo/S
 vegetal/SO
 vegetarianismo/S


### PR DESCRIPTION
¡Buenas!

Es la primera vez que contribuyo en un diccionario de este tipo. No sé si he detallado correctamente el cambio en la descripción, pero en el segundo cambio que hice (un adjetivo), he intentado especificarlo mejor. De todas formas, especifico en en esta PR el cambio tal y como lo hice en la descripción de mi segunda contribución.

Espero que ambas contribuciones estén correctas. Si no lo están, estaré encantado de recibir todos los comentarios necesarios para saber como contribuir correctamente a este recurso tan esencial.

veganismo, palabra masculina sin variación de número

Del ingl. veganism, de vegan 'vegano' e -ism '-ismo'.
1. m. Actitud consistente en rechazar alimentos o artículos de consumo de origen animal.
