### PR TITLE
[+] Agrego el adjetivo [vegano] a RAE

### DIFF
--- a/ortograf/palabras/RAE/Adjetivos.txt
+++ b/ortograf/palabras/RAE/Adjetivos.txt
@@ -12592,6 +12592,7 @@ vecino/SGf
 vectorial/S
 vector/S
 veedor/GS
+vegano/GS
 vegetalista/S
 vegetal/S
 vegetariano/GS


### PR DESCRIPTION
vegano, adjetivo con variación de número y género [vegano, vegana, veganos, veganas]

Del ingl. vegan, de vegetable 'verduras' y -an '-ano'.
1. adj. Perteneciente o relativo al veganismo.
2. adj. Que practica el veganismo.