### PR TITLE
[-] retiro la palabra [guión] de RAE

### DIFF
--- a/ortograf/palabras/RAE/NombresMasculinos.old
+++ b/ortograf/palabras/RAE/NombresMasculinos.old
@@ -181,4 +181,5 @@ desterradero/S
 diascordio/S
 disciplinante/S
 dij
+guión/S
 pre/S

--- a/ortograf/palabras/RAE/NombresMasculinos.txt
+++ b/ortograf/palabras/RAE/NombresMasculinos.txt
@@ -6452,7 +6452,6 @@ guindal/S
 guindo/S
 guiñapo/S
 guiño/S
-guión/S
 guion/S
 guipuzcoano/S
 guirigáis		# Plural de guirigay


### PR DESCRIPTION
Retiro la palabra «guión» del archivo NombresMasculinos.txt y la a su respectivo fichero <code>.old</code>. Ya no lleva tilde, véase *[Palabras como guion, truhan, fie, liais, etc., se escriben sin tilde](http://www.rae.es/consultas/palabras-como-guion-truhan-fie-liais-etc-se-escriben-sin-tilde)*.