### PR TITLE
Corrijo las marcas de git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-*~
 ortograf/tmp
+*~
 *.oxt
+*.zip

--- a/ortograf/palabras/RAE/VerbosTransitivosPronominales.txt
+++ b/ortograf/palabras/RAE/VerbosTransitivosPronominales.txt
@@ -421,13 +421,8 @@ atragantar/REDñ
 atraillar/IRD
 atrampar/RED
 atravesar/IRDÄÀÆñò
-<<<<<<< Updated upstream
 atribuir/IRDÀÁÂÃÈËÊñóT
-atribular/RED
-=======
-atribuir/IRDÀÁÂÃÈËñóT
 atribular/REDA
->>>>>>> Stashed changes
 atrincherar/REDñ
 atrofiar/RED
 atronar/IRD
@@ -571,13 +566,8 @@ concienciar/REDAñA
 conciliar/REDñA
 concitar/RED
 concrecionar/RED
-<<<<<<< Updated upstream
 concretar/REDÀÁÂñ
-condenar/REDÀÁÆÍñòT
-=======
-concretar/REDÁÂñ
 condenar/REDÀÁÆÍñòTA
->>>>>>> Stashed changes
 condensar/REDÀT
 confederar/RED
 confesar/IRDÃÅñòõ


### PR DESCRIPTION
Cuando generé el diccionario español argentina para Mozilla, me encontré con esas marcas de git. Esto hizo que sea reconocido como válido las formas "=======", "<<<<<<< Updated upstream" y ">>>>>>> Stashed changes" (pueden verlo en este [commit](https://github.com/edittler/diccionario-mozilla-es-AR/pull/2/commits/5f59c8d1cedde2563af5e27abc9f144ebc1ba9b9)). En el diccionario de mozilla eliminé eso y tuve que actualizar el contador del .dic manualmente.

Supuse que las definiciones con más flags es la correcta, pero no estoy seguro.

Esto se podría haber evitado si trabajamos mediante pull requests revisados por los demás en ves de hacer push directamente a master, donde revisar los commits es más engorroso.

Agregué también al gitignore `*.zip` ya que casi subo por error el que había generado.