### PR TITLE
Añade algunas palabras con prefijos

### DIFF
--- a/ortografia/palabras/RAE/Adjetivos.txt
+++ b/ortografia/palabras/RAE/Adjetivos.txt
@@ -952,6 +952,7 @@ antiinflamatorio/GS
 antillano/GS
 antimicrobiano/GS
 antimonial/S
+antinflamatorio/GS
 antiniebla/S
 antipático/GS
 antipersona/S
@@ -11435,6 +11436,7 @@ semiforme/S
 semiinconsciente/S
 seminal/S
 seminario/SG
+seminconsciente/S
 semiótico/GS
 semita/Sc
 semítico/GS

--- a/ortografia/palabras/RAE/NombresMasculinos.txt
+++ b/ortografia/palabras/RAE/NombresMasculinos.txt
@@ -1041,6 +1041,7 @@ antiinflamatorio/S
 antillanismo/S
 antílope/S
 antimonio/S
+antinflamatorio/S
 antipendio/S
 antispasto/S
 antojo/S
@@ -10345,6 +10346,7 @@ portapliegos
 portaplumas
 portaventanero/S
 portaviandas
+portaviones
 portazgo/S
 portazguero/S
 portazo/S
@@ -10430,6 +10432,7 @@ predicado/S
 predicamento/S
 predio
 preescolar/S
+preestreno/S
 prefacio/S
 prefecto/sS
 prefijo/S
@@ -10463,6 +10466,7 @@ presidario/S
 presidencialismo/S
 presidio/S
 prest
+prestreno/S
 préstamo/S
 preste/S
 prestigio/hS

--- a/ortografia/palabras/RAE/VerbosIntransitivos.txt
+++ b/ortografia/palabras/RAE/VerbosIntransitivos.txt
@@ -297,6 +297,7 @@ conversar/RED
 convivir/RED
 cooperar/RED
 copear/RED
+coperar/RED
 coplear/RED
 coquetear/RED
 corcovear/RED

--- a/ortografia/palabras/RAE/VerbosTransitivos.txt
+++ b/ortografia/palabras/RAE/VerbosTransitivos.txt
@@ -907,6 +907,7 @@ corchar/RED
 corcovar/RED
 corcusir/RED
 cordelar/RED
+cordinar/REDÀÁÄ
 corear/REDÄ
 coreografiar/IRD
 corlar/RED


### PR DESCRIPTION
Algunas palabras ya existían, pero faltaba la forma alternativa, y recomendada,

Según la *Ortografía de la lengua española* en «6.5.1.1 Reducción de secuencias de dos vocales iguales»:

> Sin embargo, en aquellas en que la reducción vocálica es general y
constante en la pronunciación, como ocurre en las voces de la familia de cooperar
y coordinación, o en la palabra coordenada, no serían censurables, de acuerdo
con las reglas generales anteriormente expuestas, las grafías simplificadas
coperar (coperante, coperativa, etc.), cordinación (cordinar, cordinado,
cordinadamente, etc.) o cordenada, a pesar de su escasa documentación frente a
las grafías que mantienen la doble o etimológica. 

> **Notas orientadoras para la reducción de secuencias de dos vocales iguales en
palabras prefijadas y compuestas**
> Las secuencias de dos vocales iguales en voces prefijadas o compuestas, en las
que el elemento antepuesto termina con la misma vocal por la que empieza la palabra
a la que se une, podrán reducirse a una sola en la escritura siempre que sea general en
el habla la pronunciación de una única vocal. Según esta norma, se consideran válidas
—e incluso preferibles a las grafías con doble vocal— formas como contrataque,
microrganismo, portaviones, prestreno, sobresfuerzo, antinflamatorio, seminconsciente o microrganismo

[Según Fundéu, «*portaviones*, mejor que portaaviones»](https://www.fundeu.es/recomendacion/portavionesmejor-que-portaaviones-1479/).

Imagino que hay otras palabras que siguen esta regla que se podrían añadir.