### PR TITLE
Añade palabras fan y jáquer

### DIFF
--- a/ortografia/palabras/RAE/NombresComunes.txt
+++ b/ortografia/palabras/RAE/NombresComunes.txt
@@ -457,6 +457,7 @@ intérprete/S
 intocable/S
 israelí/S
 izquierdista/S
+jáquer/S
 jefe/S
 jemer/S
 jerarca/S

--- a/ortografia/palabras/RAE/NombresComunes.txt
+++ b/ortografia/palabras/RAE/NombresComunes.txt
@@ -360,6 +360,7 @@ fabricante/S
 fabulista/S
 fagot/S
 falangista/S
+fan/S
 faramalla/S
 farfulla/S
 farraguista/S


### PR DESCRIPTION
Para el plural sigue la recomendación de la RAE: «Aunque está generalizado el uso del plural inglés *fans*, se recomienda acomodar esta palabra a la morfología española y usar *fanes* para el plural» (según el [Diccionario panhispánico de dudas](https://www.rae.es/dpd/fan)). Es decir, *fan* y *fanes* no serán marcadas como error, pero *fans* sí.