### PR TITLE
Update NombresMasculinosFemeninos.txt

### DIFF
--- a/ortografia/palabras/RAE/NombresMasculinosFemeninos.txt
+++ b/ortografia/palabras/RAE/NombresMasculinosFemeninos.txt
@@ -92,8 +92,8 @@ alemán/GS
 alfombrero/GS
 alfonsino/GS
 alforjero/GS
-algalia/S
 algodonero/GS
+alguero/GS
 alienígena/S
 alijador/GS
 almacenero/GS
@@ -914,6 +914,7 @@ gandul/GS
 garbancero/GS
 garduño/GS
 gatero/GS
+gaviero/GS
 génesis
 genético/GS
 genitor/GS
@@ -1256,6 +1257,7 @@ misionero/GS
 místico/GS
 mitólogo/GS
 mixteco/GS
+mocetón/GS
 mochilero/GS
 mocho/GS
 moderador/GS


### PR DESCRIPTION
Añado alguero/GS, gaviero/GS y mocetón/GS.
Quito algalia/S, porque el DRAE dice que es femenino, y la acepción que marca como masculino es «gato de algalia», en la cual lo masculino es «gato», no el complemento del nombre.