### PR TITLE
Update NombresPropiosSiglas.txt

### DIFF
--- a/ortografia/palabras/noRAE/NombresPropiosSiglas.txt
+++ b/ortografia/palabras/noRAE/NombresPropiosSiglas.txt
@@ -79,7 +79,7 @@ Apolonio
 Apuleyo
 Aquiles
 Araceli
-Árato
+Arato
 Arcesilao
 Ariel
 Aries
@@ -730,7 +730,7 @@ Xavier
 Yeltsin
 Yolanda
 Zacarías
-Zamolxis
+Zalmoxis
 Zedillo
 Zenódoto
 Zenón


### PR DESCRIPTION
Corrijo una tilde y una errata: Arato y Zalmoxis.