### PR TITLE
Se agrega verbo transitivo regalonear

### DIFF
--- a/ortografia/palabras/RAE/l10n/es_CL/VerbosTransitivos.txt
+++ b/ortografia/palabras/RAE/l10n/es_CL/VerbosTransitivos.txt
@@ -87,6 +87,7 @@ quiñar/RED
 rasmillar/RED
 rasquetear/RED
 refaccionar/REDÀ
+regalonear/RED
 reportear/RED
 retobar/RED
 talonear/RED


### PR DESCRIPTION
Muy buen día junto con saludar se informa que se agrega verbo transitivo _regalonear_ al diccionario es-cl.

Quedo atento a cualquier comentario.

close #364 
